### PR TITLE
Change dependencies version to latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,13 +88,13 @@ repositories {
 Then use a regular dependency like so:
 
 ```groovy
-api "scientifik:kmath-core-jvm:0.1.0-dev"
+api "scientifik:kmath-core-jvm:0.1.3-dev"
 ```
 
 or in the Gradle Kotlin DSL:
 
 ```kotlin
-api("scientifik:kmath-core-jvm:0.1.0-dev")
+api("scientifik:kmath-core-jvm:0.1.3-dev")
 ```
 
 ### Release
@@ -107,7 +107,7 @@ repositories{
 }
 
 dependencies{
-    api("scientifik:kmath-core-jvm:0.1.0")
+    api("scientifik:kmath-core-jvm:0.1.3")
 }
 ```
 


### PR DESCRIPTION
Hi. recently decide to try this library and face problem with dependency resolving. Took me some time before i realized that i copy-pasted dependency string from README and mentioned version '0.1.0' actually is not available at https://dl.bintray.com/mipt-npm/scientifik/scientifik/kmath-core-jvm/
Also had changded dev version for consistency, although can't load [repository ](http://npm.mipt.ru:8081/artifactory/gradle-dev) with nighly builds to check if there are "scientifik:kmath-core-jvm:0.1.3-dev" at all