### PR TITLE
Extend mathematic operations support in the kmath-ast parser 

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,6 +11,7 @@ allprojects {
     repositories {
         jcenter()
         maven("https://dl.bintray.com/kotlin/kotlinx")
+        maven("https://dl.bintray.com/hotkeytlt/maven")
     }
 
     group = "scientifik"

--- a/kmath-ast/build.gradle.kts
+++ b/kmath-ast/build.gradle.kts
@@ -1,10 +1,4 @@
-plugins {
-    id("scientifik.mpp")
-}
-
-repositories {
-    maven("https://dl.bintray.com/hotkeytlt/maven")
-}
+plugins { id("scientifik.mpp") }
 
 kotlin.sourceSets {
 //    all {
@@ -30,8 +24,6 @@ kotlin.sourceSets {
     }
 
     jsMain {
-        dependencies {
-            implementation("com.github.h0tk3y.betterParse:better-parse-js:0.4.0-alpha-3")
-        }
+        dependencies { implementation("com.github.h0tk3y.betterParse:better-parse-js:0.4.0-alpha-3") }
     }
 }

--- a/kmath-ast/build.gradle.kts
+++ b/kmath-ast/build.gradle.kts
@@ -9,21 +9,15 @@ kotlin.sourceSets {
     commonMain {
         dependencies {
             api(project(":kmath-core"))
-            implementation("com.github.h0tk3y.betterParse:better-parse-multiplatform:0.4.0-alpha-3")
-            implementation("com.github.h0tk3y.betterParse:better-parse-multiplatform-metadata:0.4.0-alpha-3")
+            implementation("com.github.h0tk3y.betterParse:better-parse:0.4.0")
         }
     }
 
     jvmMain {
         dependencies {
-            implementation("com.github.h0tk3y.betterParse:better-parse-jvm:0.4.0-alpha-3")
             implementation("org.ow2.asm:asm:8.0.1")
             implementation("org.ow2.asm:asm-commons:8.0.1")
             implementation(kotlin("reflect"))
         }
-    }
-
-    jsMain {
-        dependencies { implementation("com.github.h0tk3y.betterParse:better-parse-js:0.4.0-alpha-3") }
     }
 }

--- a/kmath-ast/reference/ArithmeticsEvaluator.g4
+++ b/kmath-ast/reference/ArithmeticsEvaluator.g4
@@ -1,0 +1,59 @@
+grammar ArithmeticsEvaluator;
+
+fragment DIGIT: '0'..'9';
+fragment LETTER: 'a'..'z';
+fragment UNDERSCORE: '_';
+
+ID: (LETTER | UNDERSCORE) (LETTER | UNDERSCORE | DIGIT)*;
+NUM: (DIGIT | '.')+ ([eE] MINUS? DIGIT+)?;
+MUL: '*';
+DIV: '/';
+PLUS: '+';
+MINUS: '-';
+POW: '^';
+COMMA: ',';
+LPAR: '(';
+RPAR: ')';
+WS: [ \n\t\r]+ -> skip;
+
+number
+    : NUM
+    ;
+
+singular
+    : ID
+    ;
+
+unaryFunction
+    : ID LPAR subSumChain RPAR
+    ;
+
+binaryFunction
+    : ID LPAR subSumChain COMMA subSumChain RPAR
+    ;
+
+term
+    : number
+    | singular
+    | unaryFunction
+    | binaryFunction
+    | MINUS term
+    | LPAR subSumChain RPAR
+    ;
+
+powChain
+    : term (POW term)*
+    ;
+
+
+divMulChain
+    : powChain ((PLUS | MINUS) powChain)*
+    ;
+
+subSumChain
+    : divMulChain ((DIV | MUL) divMulChain)*
+    ;
+
+rootParser
+    : subSumChain EOF
+    ;

--- a/kmath-ast/reference/ArithmeticsEvaluator.g4
+++ b/kmath-ast/reference/ArithmeticsEvaluator.g4
@@ -2,11 +2,11 @@ grammar ArithmeticsEvaluator;
 
 fragment DIGIT: '0'..'9';
 fragment LETTER: 'a'..'z';
-fragment CAPITAL_LETTER: 'A'..'Z'
+fragment CAPITAL_LETTER: 'A'..'Z';
 fragment UNDERSCORE: '_';
 
 ID: (LETTER | UNDERSCORE | CAPITAL_LETTER) (LETTER | UNDERSCORE | DIGIT | CAPITAL_LETTER)*;
-NUM: (DIGIT | '.')+ ([eE] MINUS? DIGIT+)?;
+NUM: (DIGIT | '.')+ ([eE] (MINUS? | PLUS?) DIGIT+)?;
 MUL: '*';
 DIV: '/';
 PLUS: '+';
@@ -17,7 +17,7 @@ LPAR: '(';
 RPAR: ')';
 WS: [ \n\t\r]+ -> skip;
 
-number
+num
     : NUM
     ;
 
@@ -34,7 +34,7 @@ binaryFunction
     ;
 
 term
-    : number
+    : num
     | singular
     | unaryFunction
     | binaryFunction

--- a/kmath-ast/reference/ArithmeticsEvaluator.g4
+++ b/kmath-ast/reference/ArithmeticsEvaluator.g4
@@ -6,7 +6,7 @@ fragment CAPITAL_LETTER: 'A'..'Z';
 fragment UNDERSCORE: '_';
 
 ID: (LETTER | UNDERSCORE | CAPITAL_LETTER) (LETTER | UNDERSCORE | DIGIT | CAPITAL_LETTER)*;
-NUM: (DIGIT | '.')+ ([eE] (MINUS? | PLUS?) DIGIT+)?;
+NUM: (DIGIT | '.')+ ([eE] [-+]? DIGIT+)?;
 MUL: '*';
 DIV: '/';
 PLUS: '+';

--- a/kmath-ast/reference/ArithmeticsEvaluator.g4
+++ b/kmath-ast/reference/ArithmeticsEvaluator.g4
@@ -2,9 +2,10 @@ grammar ArithmeticsEvaluator;
 
 fragment DIGIT: '0'..'9';
 fragment LETTER: 'a'..'z';
+fragment CAPITAL_LETTER: 'A'..'Z'
 fragment UNDERSCORE: '_';
 
-ID: (LETTER | UNDERSCORE) (LETTER | UNDERSCORE | DIGIT)*;
+ID: (LETTER | UNDERSCORE | CAPITAL_LETTER) (LETTER | UNDERSCORE | DIGIT | CAPITAL_LETTER)*;
 NUM: (DIGIT | '.')+ ([eE] MINUS? DIGIT+)?;
 MUL: '*';
 DIV: '/';

--- a/kmath-ast/reference/ArithmeticsEvaluator.g4
+++ b/kmath-ast/reference/ArithmeticsEvaluator.g4
@@ -46,13 +46,12 @@ powChain
     : term (POW term)*
     ;
 
-
 divMulChain
-    : powChain ((PLUS | MINUS) powChain)*
+    : powChain ((DIV | MUL) powChain)*
     ;
 
 subSumChain
-    : divMulChain ((DIV | MUL) divMulChain)*
+    : divMulChain ((PLUS | MINUS) divMulChain)*
     ;
 
 rootParser

--- a/kmath-ast/src/commonMain/kotlin/scientifik/kmath/ast/MST.kt
+++ b/kmath-ast/src/commonMain/kotlin/scientifik/kmath/ast/MST.kt
@@ -2,7 +2,6 @@ package scientifik.kmath.ast
 
 import scientifik.kmath.operations.Algebra
 import scientifik.kmath.operations.NumericAlgebra
-import scientifik.kmath.operations.RealField
 
 /**
  * A Mathematical Syntax Tree node for mathematical expressions
@@ -49,12 +48,11 @@ fun <T> Algebra<T>.evaluate(node: MST): T = when (node) {
     is MST.Binary -> when {
         this !is NumericAlgebra -> binaryOperation(node.operation, evaluate(node.left), evaluate(node.right))
         node.left is MST.Numeric && node.right is MST.Numeric -> {
-            val number = RealField.binaryOperation(
+            binaryOperation(
                 node.operation,
-                node.left.value.toDouble(),
-                node.right.value.toDouble()
+                number(node.left.value),
+                number(node.right.value)
             )
-            number(number)
         }
         node.left is MST.Numeric -> leftSideNumberOperation(node.operation, node.left.value, evaluate(node.right))
         node.right is MST.Numeric -> rightSideNumberOperation(node.operation, evaluate(node.left), node.right.value)

--- a/kmath-ast/src/commonMain/kotlin/scientifik/kmath/ast/MST.kt
+++ b/kmath-ast/src/commonMain/kotlin/scientifik/kmath/ast/MST.kt
@@ -2,6 +2,7 @@ package scientifik.kmath.ast
 
 import scientifik.kmath.operations.Algebra
 import scientifik.kmath.operations.NumericAlgebra
+import scientifik.kmath.operations.RealField
 
 /**
  * A Mathematical Syntax Tree node for mathematical expressions
@@ -47,13 +48,17 @@ fun <T> Algebra<T>.evaluate(node: MST): T = when (node) {
     is MST.Unary -> unaryOperation(node.operation, evaluate(node.value))
     is MST.Binary -> when {
         this !is NumericAlgebra -> binaryOperation(node.operation, evaluate(node.left), evaluate(node.right))
+
         node.left is MST.Numeric && node.right is MST.Numeric -> {
-            binaryOperation(
+            val number = RealField.binaryOperation(
                 node.operation,
-                number(node.left.value),
-                number(node.right.value)
+                node.left.value.toDouble(),
+                node.right.value.toDouble()
             )
+
+            number(number)
         }
+
         node.left is MST.Numeric -> leftSideNumberOperation(node.operation, node.left.value, evaluate(node.right))
         node.right is MST.Numeric -> rightSideNumberOperation(node.operation, evaluate(node.left), node.right.value)
         else -> binaryOperation(node.operation, evaluate(node.left), evaluate(node.right))

--- a/kmath-ast/src/commonMain/kotlin/scientifik/kmath/ast/MST.kt
+++ b/kmath-ast/src/commonMain/kotlin/scientifik/kmath/ast/MST.kt
@@ -41,26 +41,24 @@ sealed class MST {
 
 //TODO add a function with named arguments
 
-fun <T> Algebra<T>.evaluate(node: MST): T {
-    return when (node) {
-        is MST.Numeric -> (this as? NumericAlgebra<T>)?.number(node.value)
-            ?: error("Numeric nodes are not supported by $this")
-        is MST.Symbolic -> symbol(node.value)
-        is MST.Unary -> unaryOperation(node.operation, evaluate(node.value))
-        is MST.Binary -> when {
-            this !is NumericAlgebra -> binaryOperation(node.operation, evaluate(node.left), evaluate(node.right))
-            node.left is MST.Numeric && node.right is MST.Numeric -> {
-                val number = RealField.binaryOperation(
-                    node.operation,
-                    node.left.value.toDouble(),
-                    node.right.value.toDouble()
-                )
-                number(number)
-            }
-            node.left is MST.Numeric -> leftSideNumberOperation(node.operation, node.left.value, evaluate(node.right))
-            node.right is MST.Numeric -> rightSideNumberOperation(node.operation, evaluate(node.left), node.right.value)
-            else -> binaryOperation(node.operation, evaluate(node.left), evaluate(node.right))
+fun <T> Algebra<T>.evaluate(node: MST): T = when (node) {
+    is MST.Numeric -> (this as? NumericAlgebra<T>)?.number(node.value)
+        ?: error("Numeric nodes are not supported by $this")
+    is MST.Symbolic -> symbol(node.value)
+    is MST.Unary -> unaryOperation(node.operation, evaluate(node.value))
+    is MST.Binary -> when {
+        this !is NumericAlgebra -> binaryOperation(node.operation, evaluate(node.left), evaluate(node.right))
+        node.left is MST.Numeric && node.right is MST.Numeric -> {
+            val number = RealField.binaryOperation(
+                node.operation,
+                node.left.value.toDouble(),
+                node.right.value.toDouble()
+            )
+            number(number)
         }
+        node.left is MST.Numeric -> leftSideNumberOperation(node.operation, node.left.value, evaluate(node.right))
+        node.right is MST.Numeric -> rightSideNumberOperation(node.operation, evaluate(node.left), node.right.value)
+        else -> binaryOperation(node.operation, evaluate(node.left), evaluate(node.right))
     }
 }
 

--- a/kmath-ast/src/commonMain/kotlin/scientifik/kmath/ast/parser.kt
+++ b/kmath-ast/src/commonMain/kotlin/scientifik/kmath/ast/parser.kt
@@ -7,6 +7,7 @@ import com.github.h0tk3y.betterParse.grammar.parser
 import com.github.h0tk3y.betterParse.grammar.tryParseToEnd
 import com.github.h0tk3y.betterParse.lexer.Token
 import com.github.h0tk3y.betterParse.lexer.TokenMatch
+import com.github.h0tk3y.betterParse.lexer.regexToken
 import com.github.h0tk3y.betterParse.parser.ParseResult
 import com.github.h0tk3y.betterParse.parser.Parser
 import scientifik.kmath.operations.FieldOperations
@@ -15,20 +16,21 @@ import scientifik.kmath.operations.RingOperations
 import scientifik.kmath.operations.SpaceOperations
 
 /**
- * TODO move to common
+ * TODO move to core
  */
 object ArithmeticsEvaluator : Grammar<MST>() {
-    private val num: Token by token("[\\d.]+(?:[eE][-+]?\\d+)?".toRegex())
-    private val id: Token by token("[a-z_A-Z][\\da-z_A-Z]*".toRegex())
-    private val lpar: Token by token("\\(".toRegex())
-    private val rpar: Token by token("\\)".toRegex())
-    private val comma: Token by token(",".toRegex())
-    private val mul: Token by token("\\*".toRegex())
-    private val pow: Token by token("\\^".toRegex())
-    private val div: Token by token("/".toRegex())
-    private val minus: Token by token("-".toRegex())
-    private val plus: Token by token("\\+".toRegex())
-    private val ws: Token by token("\\s+".toRegex(), ignore = true)
+    // TODO replace with "...".toRegex() when better-parse 0.4.1 is released
+    private val num: Token by regexToken("[\\d.]+(?:[eE][-+]?\\d+)?")
+    private val id: Token by regexToken("[a-z_A-Z][\\da-z_A-Z]*")
+    private val lpar: Token by regexToken("\\(")
+    private val rpar: Token by regexToken("\\)")
+    private val comma: Token by regexToken(",")
+    private val mul: Token by regexToken("\\*")
+    private val pow: Token by regexToken("\\^")
+    private val div: Token by regexToken("/")
+    private val minus: Token by regexToken("-")
+    private val plus: Token by regexToken("\\+")
+    private val ws: Token by regexToken("\\s+", ignore = true)
 
     private val number: Parser<MST> by num use { MST.Numeric(text.toDouble()) }
     private val singular: Parser<MST> by id use { MST.Symbolic(text) }

--- a/kmath-ast/src/commonMain/kotlin/scientifik/kmath/ast/parser.kt
+++ b/kmath-ast/src/commonMain/kotlin/scientifik/kmath/ast/parser.kt
@@ -5,6 +5,8 @@ import com.github.h0tk3y.betterParse.grammar.Grammar
 import com.github.h0tk3y.betterParse.grammar.parseToEnd
 import com.github.h0tk3y.betterParse.grammar.parser
 import com.github.h0tk3y.betterParse.grammar.tryParseToEnd
+import com.github.h0tk3y.betterParse.lexer.Token
+import com.github.h0tk3y.betterParse.lexer.TokenMatch
 import com.github.h0tk3y.betterParse.parser.ParseResult
 import com.github.h0tk3y.betterParse.parser.Parser
 import scientifik.kmath.operations.FieldOperations
@@ -15,41 +17,62 @@ import scientifik.kmath.operations.SpaceOperations
 /**
  * TODO move to common
  */
-private object ArithmeticsEvaluator : Grammar<MST>() {
-    val num by token("-?[\\d.]+(?:[eE]-?\\d+)?".toRegex())
-    val lpar by token("\\(".toRegex())
-    val rpar by token("\\)".toRegex())
-    val mul by token("\\*".toRegex())
-    val pow by token("\\^".toRegex())
-    val div by token("/".toRegex())
-    val minus by token("-".toRegex())
-    val plus by token("\\+".toRegex())
-    val ws by token("\\s+".toRegex(), ignore = true)
+object ArithmeticsEvaluator : Grammar<MST>() {
+    private val num: Token by token("[\\d.]+(?:[eE]-?\\d+)?".toRegex())
+    private val id: Token by token("[a-z_][\\da-z_]*".toRegex())
+    private val lpar: Token by token("\\(".toRegex())
+    private val rpar: Token by token("\\)".toRegex())
+    private val comma: Token by token(",".toRegex())
+    private val mul: Token by token("\\*".toRegex())
+    private val pow: Token by token("\\^".toRegex())
+    private val div: Token by token("/".toRegex())
+    private val minus: Token by token("-".toRegex())
+    private val plus: Token by token("\\+".toRegex())
+    private val ws: Token by token("\\s+".toRegex(), ignore = true)
 
-    val number: Parser<MST> by num use { MST.Numeric(text.toDouble()) }
+    private val number: Parser<MST> by num use { MST.Numeric(text.toDouble()) }
+    private val singular: Parser<MST> by id use { MST.Symbolic(text) }
 
-    val term: Parser<MST> by number or
-            (skip(minus) and parser(this::term) map { MST.Unary(SpaceOperations.MINUS_OPERATION, it) }) or
-            (skip(lpar) and parser(this::rootParser) and skip(rpar))
+    private val unaryFunction: Parser<MST> by (id and skip(lpar) and parser(::subSumChain) and skip(rpar))
+        .map { (id, term) -> MST.Unary(id.text, term) }
 
-    val powChain by leftAssociative(term, pow) { a, _, b ->
+    private val binaryFunction: Parser<MST> by id
+        .and(skip(lpar))
+        .and(parser(::subSumChain))
+        .and(skip(comma))
+        .and(parser(::subSumChain))
+        .and(skip(rpar))
+        .map { (id, left, right) -> MST.Binary(id.text, left, right) }
+
+    private val term: Parser<MST> by number
+        .or(binaryFunction)
+        .or(unaryFunction)
+        .or(singular)
+        .or(skip(minus) and parser(::term) map { MST.Unary(SpaceOperations.MINUS_OPERATION, it) })
+        .or(skip(lpar) and parser(::subSumChain) and skip(rpar))
+
+    private val powChain: Parser<MST> by leftAssociative(term = term, operator = pow) { a, _, b ->
         MST.Binary(PowerOperations.POW_OPERATION, a, b)
     }
 
-    val divMulChain: Parser<MST> by leftAssociative(powChain, div or mul use { type }) { a, op, b ->
-        if (op == div) {
+    private val divMulChain: Parser<MST> by leftAssociative(
+        term = powChain,
+        operator = div or mul use TokenMatch::type
+    ) { a, op, b ->
+        if (op == div)
             MST.Binary(FieldOperations.DIV_OPERATION, a, b)
-        } else {
+        else
             MST.Binary(RingOperations.TIMES_OPERATION, a, b)
-        }
     }
 
-    val subSumChain: Parser<MST> by leftAssociative(divMulChain, plus or minus use { type }) { a, op, b ->
-        if (op == plus) {
+    private val subSumChain: Parser<MST> by leftAssociative(
+        term = divMulChain,
+        operator = plus or minus use TokenMatch::type
+    ) { a, op, b ->
+        if (op == plus)
             MST.Binary(SpaceOperations.PLUS_OPERATION, a, b)
-        } else {
+        else
             MST.Binary(SpaceOperations.MINUS_OPERATION, a, b)
-        }
     }
 
     override val rootParser: Parser<MST> by subSumChain

--- a/kmath-ast/src/commonMain/kotlin/scientifik/kmath/ast/parser.kt
+++ b/kmath-ast/src/commonMain/kotlin/scientifik/kmath/ast/parser.kt
@@ -18,7 +18,7 @@ import scientifik.kmath.operations.SpaceOperations
  * TODO move to common
  */
 object ArithmeticsEvaluator : Grammar<MST>() {
-    private val num: Token by token("[\\d.]+(?:[eE]-?\\d+)?".toRegex())
+    private val num: Token by token("[\\d.]+(?:[eE][-+]?\\d+)?".toRegex())
     private val id: Token by token("[a-z_A-Z][\\da-z_A-Z]*".toRegex())
     private val lpar: Token by token("\\(".toRegex())
     private val rpar: Token by token("\\)".toRegex())

--- a/kmath-ast/src/commonMain/kotlin/scientifik/kmath/ast/parser.kt
+++ b/kmath-ast/src/commonMain/kotlin/scientifik/kmath/ast/parser.kt
@@ -19,7 +19,7 @@ import scientifik.kmath.operations.SpaceOperations
  */
 object ArithmeticsEvaluator : Grammar<MST>() {
     private val num: Token by token("[\\d.]+(?:[eE]-?\\d+)?".toRegex())
-    private val id: Token by token("[a-z_][\\da-z_]*".toRegex())
+    private val id: Token by token("[a-z_A-Z][\\da-z_A-Z]*".toRegex())
     private val lpar: Token by token("\\(".toRegex())
     private val rpar: Token by token("\\)".toRegex())
     private val comma: Token by token(",".toRegex())

--- a/kmath-ast/src/jvmMain/kotlin/scientifik/kmath/asm/internal/AsmBuilder.kt
+++ b/kmath-ast/src/jvmMain/kotlin/scientifik/kmath/asm/internal/AsmBuilder.kt
@@ -288,7 +288,7 @@ internal class AsmBuilder<T> internal constructor(
     /**
      * Loads a [T] constant from [constants].
      */
-    private fun loadTConstant(value: T) {
+    internal fun loadTConstant(value: T) {
         if (classOfT in INLINABLE_NUMBERS) {
             val expectedType = expectationStack.pop()
             val mustBeBoxed = expectedType.sort == Type.OBJECT

--- a/kmath-ast/src/jvmTest/kotlin/scietifik/kmath/ast/ParserPrecedenceTest.kt
+++ b/kmath-ast/src/jvmTest/kotlin/scietifik/kmath/ast/ParserPrecedenceTest.kt
@@ -1,0 +1,36 @@
+package scietifik.kmath.ast
+
+import scientifik.kmath.ast.evaluate
+import scientifik.kmath.ast.parseMath
+import scientifik.kmath.operations.Field
+import scientifik.kmath.operations.RealField
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+internal class ParserPrecedenceTest {
+    private val f: Field<Double> = RealField
+
+    @Test
+    fun test1(): Unit = assertEquals(6.0, f.evaluate("2*2+2".parseMath()))
+
+    @Test
+    fun test2(): Unit = assertEquals(6.0, f.evaluate("2+2*2".parseMath()))
+
+    @Test
+    fun test3(): Unit = assertEquals(10.0, f.evaluate("2^3+2".parseMath()))
+
+    @Test
+    fun test4(): Unit = assertEquals(10.0, f.evaluate("2+2^3".parseMath()))
+
+    @Test
+    fun test5(): Unit = assertEquals(16.0, f.evaluate("2^3*2".parseMath()))
+
+    @Test
+    fun test6(): Unit = assertEquals(16.0, f.evaluate("2*2^3".parseMath()))
+
+    @Test
+    fun test7(): Unit = assertEquals(18.0, f.evaluate("2+2^3*2".parseMath()))
+
+    @Test
+    fun test8(): Unit = assertEquals(18.0, f.evaluate("2*2^3+2".parseMath()))
+}

--- a/kmath-ast/src/jvmTest/kotlin/scietifik/kmath/ast/ParserTest.kt
+++ b/kmath-ast/src/jvmTest/kotlin/scietifik/kmath/ast/ParserTest.kt
@@ -4,8 +4,10 @@ import scientifik.kmath.ast.evaluate
 import scientifik.kmath.ast.mstInField
 import scientifik.kmath.ast.parseMath
 import scientifik.kmath.expressions.invoke
+import scientifik.kmath.operations.Algebra
 import scientifik.kmath.operations.Complex
 import scientifik.kmath.operations.ComplexField
+import scientifik.kmath.operations.RealField
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -21,5 +23,38 @@ internal class ParserTest {
     fun `evaluate MSTExpression`() {
         val res = ComplexField.mstInField { number(2) + number(2) * (number(2) + number(2)) }()
         assertEquals(Complex(10.0, 0.0), res)
+    }
+
+    @Test
+    fun `evaluate MST with singular`() {
+        val mst = "i".parseMath()
+        val res = ComplexField.evaluate(mst)
+        assertEquals(ComplexField.i, res)
+    }
+
+
+    @Test
+    fun `evaluate MST with unary function`() {
+        val mst = "sin(0)".parseMath()
+        val res = RealField.evaluate(mst)
+        assertEquals(0.0, res)
+    }
+
+    @Test
+    fun `evaluate MST with binary function`() {
+        val magicalAlgebra = object : Algebra<String> {
+            override fun symbol(value: String): String = value
+
+            override fun unaryOperation(operation: String, arg: String): String = throw NotImplementedError()
+
+            override fun binaryOperation(operation: String, left: String, right: String): String = when (operation) {
+                "magic" -> "$left ★ $right"
+                else -> throw NotImplementedError()
+            }
+        }
+
+        val mst = "magic(a, b)".parseMath()
+        val res = magicalAlgebra.evaluate(mst)
+        assertEquals("a ★ b", res)
     }
 }

--- a/kmath-core/src/commonMain/kotlin/scientifik/kmath/operations/NumberAlgebra.kt
+++ b/kmath-core/src/commonMain/kotlin/scientifik/kmath/operations/NumberAlgebra.kt
@@ -34,6 +34,13 @@ interface ExtendedField<T> : ExtendedFieldOperations<T>, Field<T> {
     }
 }
 
+interface NumberExtendedField<T> : ExtendedField<T> {
+    override fun binaryOperation(operation: String, left: T, right: T): T = when (operation) {
+        PowerOperations.POW_OPERATION -> power(left, right as Number)
+        else -> super.binaryOperation(operation, left, right)
+    }
+}
+
 /**
  * Real field element wrapping double.
  *
@@ -53,7 +60,7 @@ inline class Real(val value: Double) : FieldElement<Double, Real, RealField> {
  * A field for double without boxing. Does not produce appropriate field element
  */
 @Suppress("EXTENSION_SHADOWED_BY_MEMBER", "OVERRIDE_BY_INLINE", "NOTHING_TO_INLINE")
-object RealField : ExtendedField<Double>, Norm<Double, Double> {
+object RealField : NumberExtendedField<Double>, Norm<Double, Double> {
     override val zero: Double = 0.0
     override inline fun add(a: Double, b: Double) = a + b
     override inline fun multiply(a: Double, b: Double) = a * b
@@ -88,7 +95,7 @@ object RealField : ExtendedField<Double>, Norm<Double, Double> {
 }
 
 @Suppress("EXTENSION_SHADOWED_BY_MEMBER", "OVERRIDE_BY_INLINE", "NOTHING_TO_INLINE")
-object FloatField : ExtendedField<Float>, Norm<Float, Float> {
+object FloatField : NumberExtendedField<Float>, Norm<Float, Float> {
     override val zero: Float = 0f
     override inline fun add(a: Float, b: Float) = a + b
     override inline fun multiply(a: Float, b: Float) = a * b

--- a/kmath-core/src/commonMain/kotlin/scientifik/kmath/operations/NumberAlgebra.kt
+++ b/kmath-core/src/commonMain/kotlin/scientifik/kmath/operations/NumberAlgebra.kt
@@ -1,5 +1,6 @@
 package scientifik.kmath.operations
 
+import scientifik.kmath.operations.RealField.pow
 import kotlin.math.abs
 import kotlin.math.pow as kpow
 
@@ -34,13 +35,6 @@ interface ExtendedField<T> : ExtendedFieldOperations<T>, Field<T> {
     }
 }
 
-interface NumberExtendedField<T> : ExtendedField<T> {
-    override fun binaryOperation(operation: String, left: T, right: T): T = when (operation) {
-        PowerOperations.POW_OPERATION -> power(left, right as Number)
-        else -> super.binaryOperation(operation, left, right)
-    }
-}
-
 /**
  * Real field element wrapping double.
  *
@@ -60,7 +54,7 @@ inline class Real(val value: Double) : FieldElement<Double, Real, RealField> {
  * A field for double without boxing. Does not produce appropriate field element
  */
 @Suppress("EXTENSION_SHADOWED_BY_MEMBER", "OVERRIDE_BY_INLINE", "NOTHING_TO_INLINE")
-object RealField : NumberExtendedField<Double>, Norm<Double, Double> {
+object RealField : ExtendedField<Double>, Norm<Double, Double> {
     override val zero: Double = 0.0
     override inline fun add(a: Double, b: Double) = a + b
     override inline fun multiply(a: Double, b: Double) = a * b
@@ -92,10 +86,15 @@ object RealField : NumberExtendedField<Double>, Norm<Double, Double> {
     override inline fun Double.times(b: Double) = this * b
 
     override inline fun Double.div(b: Double) = this / b
+
+    override fun binaryOperation(operation: String, left: Double, right: Double): Double = when (operation) {
+        PowerOperations.POW_OPERATION -> left pow right
+        else -> super.binaryOperation(operation, left, right)
+    }
 }
 
 @Suppress("EXTENSION_SHADOWED_BY_MEMBER", "OVERRIDE_BY_INLINE", "NOTHING_TO_INLINE")
-object FloatField : NumberExtendedField<Float>, Norm<Float, Float> {
+object FloatField : ExtendedField<Float>, Norm<Float, Float> {
     override val zero: Float = 0f
     override inline fun add(a: Float, b: Float) = a + b
     override inline fun multiply(a: Float, b: Float) = a * b


### PR DESCRIPTION
- Add reference ANTLR grammar.
- Add symbols support in ASM MST matcher.
- Extend parser to support singular values (like i in ComplexField) as well as unary and binary functions.

closes #117