### PR TITLE
Multiple performance improvements related to ASM

### DIFF
--- a/benchmarks/build.gradle.kts
+++ b/benchmarks/build.gradle.kts
@@ -72,9 +72,9 @@ benchmark {
     }
 
     fun kotlinx.benchmark.gradle.BenchmarkConfiguration.commonConfiguration() {
-        warmups = 1
+        warmups = 2
         iterations = 5
-        iterationTime = 1000
+        iterationTime = 2000
         iterationTimeUnit = "ms"
     }
 
@@ -143,7 +143,7 @@ kotlin.sourceSets.all {
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
     kotlinOptions {
         jvmTarget = "11"
-        freeCompilerArgs = freeCompilerArgs + "-Xjvm-default=all"
+        freeCompilerArgs = freeCompilerArgs + "-Xjvm-default=all" + "-Xlambdas=indy"
     }
 }
 

--- a/benchmarks/src/jvmMain/kotlin/space/kscience/kmath/benchmarks/ExpressionsInterpretersBenchmark.kt
+++ b/benchmarks/src/jvmMain/kotlin/space/kscience/kmath/benchmarks/ExpressionsInterpretersBenchmark.kt
@@ -62,9 +62,11 @@ internal class ExpressionsInterpretersBenchmark {
     private fun invokeAndSum(expr: Expression<Double>, blackhole: Blackhole) {
         val random = Random(0)
         var sum = 0.0
+        val m = HashMap<Symbol, Double>()
 
         repeat(times) {
-            sum += expr(x to random.nextDouble())
+            m[x] = random.nextDouble()
+            sum += expr(m)
         }
 
         blackhole.consume(sum)

--- a/buildSrc/src/main/kotlin/space/kscience/kmath/benchmarks/addBenchmarkProperties.kt
+++ b/buildSrc/src/main/kotlin/space/kscience/kmath/benchmarks/addBenchmarkProperties.kt
@@ -54,7 +54,7 @@ fun Project.addBenchmarkProperties() {
                         LocalDateTime.parse(it.name, ISO_DATE_TIME).atZone(ZoneId.systemDefault()).toInstant()
                     }
 
-                    if (resDirectory == null) {
+                    if (resDirectory == null || !(resDirectory.resolve("jvm.json")).exists()) {
                         "> **Can't find appropriate benchmark data. Try generating readme files after running benchmarks**."
                     } else {
                         val reports =

--- a/examples/build.gradle.kts
+++ b/examples/build.gradle.kts
@@ -64,9 +64,9 @@ kotlin.sourceSets.all {
 }
 
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
-    kotlinOptions{
+    kotlinOptions {
         jvmTarget = "11"
-        freeCompilerArgs = freeCompilerArgs + "-Xjvm-default=all" + "-Xopt-in=kotlin.RequiresOptIn"
+        freeCompilerArgs = freeCompilerArgs + "-Xjvm-default=all" + "-Xopt-in=kotlin.RequiresOptIn" + "-Xlambdas=indy"
     }
 }
 

--- a/examples/src/main/kotlin/space/kscience/kmath/ast/expressions.kt
+++ b/examples/src/main/kotlin/space/kscience/kmath/ast/expressions.kt
@@ -5,18 +5,22 @@
 
 package space.kscience.kmath.ast
 
+import space.kscience.kmath.asm.compileToExpression
 import space.kscience.kmath.expressions.MstField
+import space.kscience.kmath.expressions.Symbol
 import space.kscience.kmath.expressions.Symbol.Companion.x
-import space.kscience.kmath.expressions.interpret
 import space.kscience.kmath.operations.DoubleField
 import space.kscience.kmath.operations.invoke
 
 fun main() {
     val expr = MstField {
         x * 2.0 + number(2.0) / x - 16.0
-    }
+    }.compileToExpression(DoubleField)
+
+    val m = HashMap<Symbol, Double>()
 
     repeat(10000000) {
-        expr.interpret(DoubleField, x to 1.0)
+        m[x] = 1.0
+        expr(m)
     }
 }

--- a/kmath-core/build.gradle.kts
+++ b/kmath-core/build.gradle.kts
@@ -5,10 +5,21 @@ plugins {
 //    id("com.xcporter.metaview") version "0.0.5"
 }
 
-kotlin.sourceSets {
-    commonMain {
-        dependencies {
-            api(project(":kmath-memory"))
+kotlin {
+    jvm {
+        compilations.all {
+            kotlinOptions {
+                freeCompilerArgs =
+                    freeCompilerArgs + "-Xjvm-default=all" + "-Xopt-in=kotlin.RequiresOptIn" + "-Xlambdas=indy"
+            }
+        }
+    }
+
+    sourceSets {
+        commonMain {
+            dependencies {
+                api(project(":kmath-memory"))
+            }
         }
     }
 }

--- a/kmath-core/src/commonMain/kotlin/space/kscience/kmath/expressions/Expression.kt
+++ b/kmath-core/src/commonMain/kotlin/space/kscience/kmath/expressions/Expression.kt
@@ -29,7 +29,7 @@ public fun interface Expression<T> {
  *
  * @return a value.
  */
-public operator fun <T> Expression<T>.invoke(): T = invoke(emptyMap())
+public operator fun <T> Expression<T>.invoke(): T = this(emptyMap())
 
 /**
  * Calls this expression from arguments.
@@ -38,7 +38,13 @@ public operator fun <T> Expression<T>.invoke(): T = invoke(emptyMap())
  * @return a value.
  */
 @JvmName("callBySymbol")
-public operator fun <T> Expression<T>.invoke(vararg pairs: Pair<Symbol, T>): T = invoke(mapOf(*pairs))
+public operator fun <T> Expression<T>.invoke(vararg pairs: Pair<Symbol, T>): T = this(
+    when (pairs.size) {
+        0 -> emptyMap()
+        1 -> mapOf(pairs[0])
+        else -> hashMapOf(*pairs)
+    }
+)
 
 /**
  * Calls this expression from arguments.
@@ -47,8 +53,21 @@ public operator fun <T> Expression<T>.invoke(vararg pairs: Pair<Symbol, T>): T =
  * @return a value.
  */
 @JvmName("callByString")
-public operator fun <T> Expression<T>.invoke(vararg pairs: Pair<String, T>): T =
-    invoke(mapOf(*pairs).mapKeys { StringSymbol(it.key) })
+public operator fun <T> Expression<T>.invoke(vararg pairs: Pair<String, T>): T = this(
+    when (pairs.size) {
+        0 -> emptyMap()
+
+        1 -> {
+            val (k, v) = pairs[0]
+            mapOf(StringSymbol(k) to v)
+        }
+
+        else -> hashMapOf(*Array<Pair<Symbol, T>>(pairs.size) {
+            val (k, v) = pairs[it]
+            StringSymbol(k) to v
+        })
+    }
+)
 
 
 /**


### PR DESCRIPTION
1. Argument values are cached in locals
2. Optimized Expression.invoke function
3. `Xlambda=indy` is used in kmath-core