### PR TITLE
Relax type requirements in algebraExtensions.kt from `Ring` to `Group`

### DIFF
--- a/kmath-core/src/commonMain/kotlin/space/kscience/kmath/operations/algebraExtensions.kt
+++ b/kmath-core/src/commonMain/kotlin/space/kscience/kmath/operations/algebraExtensions.kt
@@ -6,55 +6,55 @@
 package space.kscience.kmath.operations
 
 /**
- * Returns the sum of all elements in the iterable in this [Ring].
+ * Returns the sum of all elements in the iterable in this [Group].
  *
  * @receiver the algebra that provides addition.
  * @param data the iterable to sum up.
  * @return the sum.
  */
-public fun <T> Ring<T>.sum(data: Iterable<T>): T = data.fold(zero) { left, right ->
+public fun <T> Group<T>.sum(data: Iterable<T>): T = data.fold(zero) { left, right ->
     add(left, right)
 }
 
 //TODO replace by sumOf with multi-receivers
 
 /**
- * Returns the sum of all elements in the sequence in this [Ring].
+ * Returns the sum of all elements in the sequence in this [Group].
  *
  * @receiver the algebra that provides addition.
  * @param data the sequence to sum up.
  * @return the sum.
  */
-public fun <T> Ring<T>.sum(data: Sequence<T>): T = data.fold(zero) { left, right ->
+public fun <T> Group<T>.sum(data: Sequence<T>): T = data.fold(zero) { left, right ->
     add(left, right)
 }
 
 /**
- * Returns an average value of elements in the iterable in this [Ring].
+ * Returns an average value of elements in the iterable in this [Group].
  *
  * @receiver the algebra that provides addition and division.
  * @param data the iterable to find average.
  * @return the average value.
  * @author Iaroslav Postovalov
  */
-public fun <T, S> S.average(data: Iterable<T>): T where S : Ring<T>, S : ScaleOperations<T> =
+public fun <T, S> S.average(data: Iterable<T>): T where S : Group<T>, S : ScaleOperations<T> =
     sum(data) / data.count()
 
 /**
- * Returns an average value of elements in the sequence in this [Ring].
+ * Returns an average value of elements in the sequence in this [Group].
  *
  * @receiver the algebra that provides addition and division.
  * @param data the sequence to find average.
  * @return the average value.
  * @author Iaroslav Postovalov
  */
-public fun <T, S> S.average(data: Sequence<T>): T where S : Ring<T>, S : ScaleOperations<T> =
+public fun <T, S> S.average(data: Sequence<T>): T where S : Group<T>, S : ScaleOperations<T> =
     sum(data) / data.count()
 
 /**
  * Absolute of the comparable [value]
  */
-public fun <T : Comparable<T>> Ring<T>.abs(value: T): T = if (value > zero) value else -value
+public fun <T : Comparable<T>> Group<T>.abs(value: T): T = if (value > zero) value else -value
 
 /**
  * Returns the sum of all elements in the iterable in provided space.
@@ -63,7 +63,7 @@ public fun <T : Comparable<T>> Ring<T>.abs(value: T): T = if (value > zero) valu
  * @param group the algebra that provides addition.
  * @return the sum.
  */
-public fun <T> Iterable<T>.sumWith(group: Ring<T>): T = group.sum(this)
+public fun <T> Iterable<T>.sumWith(group: Group<T>): T = group.sum(this)
 
 /**
  * Returns the sum of all elements in the sequence in provided space.
@@ -72,27 +72,27 @@ public fun <T> Iterable<T>.sumWith(group: Ring<T>): T = group.sum(this)
  * @param group the algebra that provides addition.
  * @return the sum.
  */
-public fun <T> Sequence<T>.sumWith(group: Ring<T>): T = group.sum(this)
+public fun <T> Sequence<T>.sumWith(group: Group<T>): T = group.sum(this)
 
 /**
- * Returns an average value of elements in the iterable in this [Ring].
+ * Returns an average value of elements in the iterable in this [Group].
  *
  * @receiver the iterable to find average.
  * @param space the algebra that provides addition and division.
  * @return the average value.
  * @author Iaroslav Postovalov
  */
-public fun <T, S> Iterable<T>.averageWith(space: S): T where S : Ring<T>, S : ScaleOperations<T> =
+public fun <T, S> Iterable<T>.averageWith(space: S): T where S : Group<T>, S : ScaleOperations<T> =
     space.average(this)
 
 /**
- * Returns an average value of elements in the sequence in this [Ring].
+ * Returns an average value of elements in the sequence in this [Group].
  *
  * @receiver the sequence to find average.
  * @param space the algebra that provides addition and division.
  * @return the average value.
  * @author Iaroslav Postovalov
  */
-public fun <T, S> Sequence<T>.averageWith(space: S): T where S : Ring<T>, S : ScaleOperations<T> =
+public fun <T, S> Sequence<T>.averageWith(space: S): T where S : Group<T>, S : ScaleOperations<T> =
     space.average(this)
 


### PR DESCRIPTION
closes #411 