### PR TITLE
Update Kotlin∇ and remove old Maven repositories

### DIFF
--- a/benchmarks/build.gradle.kts
+++ b/benchmarks/build.gradle.kts
@@ -14,12 +14,6 @@ sourceSets.register("benchmarks")
 repositories {
     mavenCentral()
     maven("https://repo.kotlin.link")
-    maven("https://clojars.org/repo")
-    maven("https://jitpack.io")
-
-    maven("http://logicrunch.research.it.uu.se/maven") {
-        isAllowInsecureProtocol = true
-    }
 }
 
 kotlin {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,13 +7,6 @@ plugins {
 
 allprojects {
     repositories {
-        maven("https://clojars.org/repo")
-        maven("https://jitpack.io")
-
-        maven("http://logicrunch.research.it.uu.se/maven") {
-            isAllowInsecureProtocol = true
-        }
-
         maven("https://oss.sonatype.org/content/repositories/snapshots")
         mavenCentral()
     }

--- a/examples/build.gradle.kts
+++ b/examples/build.gradle.kts
@@ -5,12 +5,7 @@ plugins {
 repositories {
     mavenCentral()
     maven("https://repo.kotlin.link")
-    maven("https://clojars.org/repo")
-    maven("https://jitpack.io")
     maven("https://maven.pkg.jetbrains.space/kotlin/p/kotlin/kotlin-js-wrappers")
-    maven("http://logicrunch.research.it.uu.se/maven") {
-        isAllowInsecureProtocol = true
-    }
 }
 
 dependencies {

--- a/kmath-kotlingrad/build.gradle.kts
+++ b/kmath-kotlingrad/build.gradle.kts
@@ -6,8 +6,8 @@ plugins {
 description = "Kotlin∇ integration module"
 
 dependencies {
-    api("com.github.breandan:kaliningraph:0.1.6")
-    api("com.github.breandan:kotlingrad:0.4.5")
+    api("ai.hypergraph:kaliningraph:0.1.9")
+    api("ai.hypergraph:kotlingrad:0.4.7")
     api(project(":kmath-core"))
     testImplementation(project(":kmath-ast"))
 }

--- a/kmath-kotlingrad/src/main/kotlin/space/kscience/kmath/kotlingrad/KMathNumber.kt
+++ b/kmath-kotlingrad/src/main/kotlin/space/kscience/kmath/kotlingrad/KMathNumber.kt
@@ -5,7 +5,7 @@
 
 package space.kscience.kmath.kotlingrad
 
-import edu.umontreal.kotlingrad.api.SConst
+import ai.hypergraph.kotlingrad.api.SConst
 import space.kscience.kmath.operations.NumericAlgebra
 
 /**

--- a/kmath-kotlingrad/src/main/kotlin/space/kscience/kmath/kotlingrad/KotlingradExpression.kt
+++ b/kmath-kotlingrad/src/main/kotlin/space/kscience/kmath/kotlingrad/KotlingradExpression.kt
@@ -5,8 +5,8 @@
 
 package space.kscience.kmath.kotlingrad
 
-import edu.umontreal.kotlingrad.api.SFun
-import edu.umontreal.kotlingrad.api.SVar
+import ai.hypergraph.kotlingrad.api.SFun
+import ai.hypergraph.kotlingrad.api.SVar
 import space.kscience.kmath.expressions.*
 import space.kscience.kmath.operations.NumericAlgebra
 

--- a/kmath-kotlingrad/src/main/kotlin/space/kscience/kmath/kotlingrad/scalarsAdapters.kt
+++ b/kmath-kotlingrad/src/main/kotlin/space/kscience/kmath/kotlingrad/scalarsAdapters.kt
@@ -5,7 +5,7 @@
 
 package space.kscience.kmath.kotlingrad
 
-import edu.umontreal.kotlingrad.api.*
+import ai.hypergraph.kotlingrad.api.*
 import space.kscience.kmath.expressions.MST
 import space.kscience.kmath.expressions.MstExtendedField
 import space.kscience.kmath.expressions.MstExtendedField.unaryMinus

--- a/kmath-kotlingrad/src/test/kotlin/space/kscience/kmath/kotlingrad/AdaptingTests.kt
+++ b/kmath-kotlingrad/src/test/kotlin/space/kscience/kmath/kotlingrad/AdaptingTests.kt
@@ -5,7 +5,7 @@
 
 package space.kscience.kmath.kotlingrad
 
-import edu.umontreal.kotlingrad.api.*
+import ai.hypergraph.kotlingrad.api.*
 import space.kscience.kmath.asm.compileToExpression
 import space.kscience.kmath.ast.parseMath
 import space.kscience.kmath.expressions.MstNumericAlgebra
@@ -22,7 +22,7 @@ internal class AdaptingTests {
     fun symbol() {
         assertEquals(x.identity, x.toSVar<KMathNumber<Double, DoubleField>>().name)
         val c2 = "kitten".parseMath().toSFun<KMathNumber<Double, DoubleField>>()
-        if (c2 is SVar) assertTrue(c2.name == "kitten") else fail()
+        if (c2 is SVar<*>) assertTrue(c2.name == "kitten") else fail()
     }
 
     @Test
@@ -30,17 +30,17 @@ internal class AdaptingTests {
         val c1 = MstNumericAlgebra.number(12354324)
         assertTrue(c1.toSConst<DReal>().doubleValue == 12354324.0)
         val c2 = "0.234".parseMath().toSFun<KMathNumber<Double, DoubleField>>()
-        if (c2 is SConst) assertTrue(c2.doubleValue == 0.234) else fail()
+        if (c2 is SConst<*>) assertTrue(c2.doubleValue == 0.234) else fail()
         val c3 = "1e-3".parseMath().toSFun<KMathNumber<Double, DoubleField>>()
-        if (c3 is SConst) assertEquals(0.001, c3.value) else fail()
+        if (c3 is SConst<*>) assertEquals(0.001, c3.value) else fail()
     }
 
     @Test
     fun simpleFunctionShape() {
         val linear = "2*x+16".parseMath().toSFun<KMathNumber<Double, DoubleField>>()
-        if (linear !is Sum) fail()
-        if (linear.left !is Prod) fail()
-        if (linear.right !is SConst) fail()
+        if (linear !is Sum<*>) fail()
+        if (linear.left !is Prod<*>) fail()
+        if (linear.right !is SConst<*>) fail()
     }
 
     @Test


### PR DESCRIPTION
Kotlin∇ `0.4.7` now implements breandan/kotlingrad#24 and contains various bug fixes and performance updates. I also removed several external dependencies and their repositories that were causing unstable builds in breandan/kaliningraph#3.