### PR TITLE
Implement much faster dot product algorithm for tensors

### DIFF
--- a/benchmarks/src/jvmMain/kotlin/space/kscience/kmath/benchmarks/DotBenchmark.kt
+++ b/benchmarks/src/jvmMain/kotlin/space/kscience/kmath/benchmarks/DotBenchmark.kt
@@ -15,7 +15,9 @@ import space.kscience.kmath.linear.invoke
 import space.kscience.kmath.linear.linearSpace
 import space.kscience.kmath.multik.multikAlgebra
 import space.kscience.kmath.operations.DoubleField
+import space.kscience.kmath.operations.invoke
 import space.kscience.kmath.structures.Buffer
+import space.kscience.kmath.tensors.core.DoubleTensorAlgebra
 import kotlin.random.Random
 
 @State(Scope.Benchmark)
@@ -31,6 +33,9 @@ internal class DotBenchmark {
         val matrix2 = DoubleField.linearSpace.buildMatrix(dim, dim) { _, _ ->
             random.nextDouble()
         }
+
+        val tensor1 = DoubleTensorAlgebra.randomNormal(shape = intArrayOf(dim, dim), 12224)
+        val tensor2 = DoubleTensorAlgebra.randomNormal(shape = intArrayOf(dim, dim), 12225)
 
         val cmMatrix1 = CMLinearSpace { matrix1.toCM() }
         val cmMatrix2 = CMLinearSpace { matrix2.toCM() }
@@ -77,5 +82,10 @@ internal class DotBenchmark {
     @Benchmark
     fun doubleDot(blackhole: Blackhole) = with(DoubleField.linearSpace) {
         blackhole.consume(matrix1 dot matrix2)
+    }
+
+    @Benchmark
+    fun doubleTensorDot(blackhole: Blackhole) = DoubleTensorAlgebra.invoke {
+        blackhole.consume(tensor1 dot tensor2)
     }
 }

--- a/kmath-tensors/src/commonMain/kotlin/space/kscience/kmath/tensors/core/DoubleTensorAlgebra.kt
+++ b/kmath-tensors/src/commonMain/kotlin/space/kscience/kmath/tensors/core/DoubleTensorAlgebra.kt
@@ -421,7 +421,7 @@ public open class DoubleTensorAlgebra :
 
         for ((res, ab) in resTensor.matrixSequence().zip(newThis.matrixSequence().zip(newOther.matrixSequence()))) {
             val (a, b) = ab
-            dotTo(a.as2D(), b.as2D(), res.as2D(), l, m1, n)
+            dotTo(a, b, res, l, m1, n)
         }
 
         return if (penultimateDim) {

--- a/kmath-tensors/src/commonMain/kotlin/space/kscience/kmath/tensors/core/internal/linUtils.kt
+++ b/kmath-tensors/src/commonMain/kotlin/space/kscience/kmath/tensors/core/internal/linUtils.kt
@@ -54,18 +54,26 @@ internal val <T> BufferedTensor<T>.matrices: VirtualBuffer<BufferedTensor<T>>
 internal fun <T> BufferedTensor<T>.matrixSequence(): Sequence<BufferedTensor<T>> = matrices.asSequence()
 
 internal fun dotTo(
-    a: MutableStructure2D<Double>,
-    b: MutableStructure2D<Double>,
-    res: MutableStructure2D<Double>,
+    a: BufferedTensor<Double>,
+    b: BufferedTensor<Double>,
+    res: BufferedTensor<Double>,
     l: Int, m: Int, n: Int,
 ) {
+    val aStart = a.bufferStart
+    val bStart = b.bufferStart
+    val resStart = res.bufferStart
+
+    val aBuffer = a.mutableBuffer
+    val bBuffer = b.mutableBuffer
+    val resBuffer = res.mutableBuffer
+
     for (i in 0 until l) {
         for (j in 0 until n) {
             var curr = 0.0
             for (k in 0 until m) {
-                curr += a[i, k] * b[k, j]
+                curr += aBuffer[aStart + i * m + k] * bBuffer[bStart + k * n + j]
             }
-            res[i, j] = curr
+            resBuffer[resStart + i * n + j] = curr
         }
     }
 }

--- a/kmath-tensors/src/commonTest/kotlin/space/kscience/kmath/tensors/core/TestDoubleTensorAlgebra.kt
+++ b/kmath-tensors/src/commonTest/kotlin/space/kscience/kmath/tensors/core/TestDoubleTensorAlgebra.kt
@@ -107,6 +107,8 @@ internal class TestDoubleTensorAlgebra {
         val tensor11 = fromArray(intArrayOf(3, 2), doubleArrayOf(1.0, 2.0, 3.0, 4.0, 5.0, 6.0))
         val tensor2 = fromArray(intArrayOf(3), doubleArrayOf(10.0, 20.0, 30.0))
         val tensor3 = fromArray(intArrayOf(1, 1, 3), doubleArrayOf(-1.0, -2.0, -3.0))
+        val tensor4 = fromArray(intArrayOf(2, 3, 3), (1..18).map { it.toDouble() }.toDoubleArray())
+        val tensor5 = fromArray(intArrayOf(2, 3, 3), (1..18).map { 1 + it.toDouble() }.toDoubleArray())
 
         val res12 = tensor1.dot(tensor2)
         assertTrue(res12.mutableBuffer.array() contentEquals doubleArrayOf(140.0, 320.0))
@@ -123,6 +125,13 @@ internal class TestDoubleTensorAlgebra {
         val res11 = tensor1.dot(tensor11)
         assertTrue(res11.mutableBuffer.array() contentEquals doubleArrayOf(22.0, 28.0, 49.0, 64.0))
         assertTrue(res11.shape contentEquals intArrayOf(2, 2))
+
+        val res45 = tensor4.dot(tensor5)
+        assertTrue(res45.mutableBuffer.array() contentEquals doubleArrayOf(
+            36.0, 42.0, 48.0, 81.0, 96.0, 111.0, 126.0, 150.0, 174.0,
+            468.0, 501.0, 534.0, 594.0, 636.0, 678.0, 720.0, 771.0, 822.0
+        ))
+        assertTrue(res45.shape contentEquals intArrayOf(2, 3, 3))
     }
 
     @Test


### PR DESCRIPTION
It is very simple optimization. Using async profiler I found that get method for MutableStructure is bottle neck because of excess work with array index. So I replaced it with direct access to buffer.
Before optimization:
```
Warm-up 1: 9.578 ops/s
Iteration 1: 11.363 ops/s
Iteration 2: 13.047 ops/s
Iteration 3: 13.005 ops/s
Iteration 4: 13.100 ops/s
Iteration 5: 13.213 ops/s

12.746 ±(99.9%) 2.992 ops/s [Average]
  (min, avg, max) = (11.363, 12.746, 13.213), stdev = 0.777
  CI (99.9%): [9.754, 15.738] (assumes normal distribution)


jvm summary:
Benchmark                      Mode  Cnt   Score   Error  Units
DotBenchmark.doubleTensorDot  thrpt    5  12.746 ± 2.992  ops/s
```
With optimization:
```
Warm-up 1: 1011.034 ops/s
Iteration 1: 1118.790 ops/s
Iteration 2: 1125.854 ops/s
Iteration 3: 1130.888 ops/s
Iteration 4: 1148.842 ops/s
Iteration 5: 1149.498 ops/s

1134.774 ±(99.9%) 53.246 ops/s [Average]
  (min, avg, max) = (1118.790, 1134.774, 1149.498), stdev = 13.828
  CI (99.9%): [1081.528, 1188.021] (assumes normal distribution)


jvm summary:
Benchmark                      Mode  Cnt     Score    Error  Units
DotBenchmark.doubleTensorDot  thrpt    5  1134.774 ± 53.246  ops/s
```
Total increase in performance is around 100x...
Correctness of dot product was checked using space.kscience.kmath.tensors.core.TestDoubleTensorAlgebra#testDot test.

