### PR TITLE
Inlined LaTeX formula

### DIFF
--- a/kmath-ast/README.md
+++ b/kmath-ast/README.md
@@ -199,10 +199,7 @@ public fun main() {
 
 Result LaTeX:
 
-<div style="background-color:white;">
-
-![](https://latex.codecogs.com/gif.latex?%5Coperatorname{exp}%5C,%5Cleft(%5Csqrt{x}%5Cright)-%5Cfrac{%5Cfrac{%5Coperatorname{arcsin}%5C,%5Cleft(2%5C,x%5Cright)}{2%5Ctimes10^{10}%2Bx^{3}}}{12}+x^{2/3})
-</div>
+$$\operatorname{exp}\\,\left(\sqrt{x}\right)-\frac{\frac{\operatorname{arcsin}\\,\left(2\,x\right)}{2\times10^{10}%2Bx^{3}}}{12}+x^{2/3}$$
 
 Result MathML (can be used with MathJax or other renderers):
 

--- a/kmath-ast/README.md
+++ b/kmath-ast/README.md
@@ -199,7 +199,7 @@ public fun main() {
 
 Result LaTeX:
 
-$$\operatorname{exp}\\,\left(\sqrt{x}\right)-\frac{\frac{\operatorname{arcsin}\\,\left(2\,x\right)}{2\times10^{10}%2Bx^{3}}}{12}+x^{2/3}$$
+$$\operatorname{exp}\\,\left(\sqrt{x}\right)-\frac{\frac{\operatorname{arcsin}\\,\left(2\\,x\right)}{2\times10^{10}+x^{3}}}{12}+x^{2/3}$$
 
 Result MathML (can be used with MathJax or other renderers):
 

--- a/kmath-ast/docs/README-TEMPLATE.md
+++ b/kmath-ast/docs/README-TEMPLATE.md
@@ -170,10 +170,7 @@ public fun main() {
 
 Result LaTeX:
 
-<div style="background-color:white;">
-
-![](https://latex.codecogs.com/gif.latex?%5Coperatorname{exp}%5C,%5Cleft(%5Csqrt{x}%5Cright)-%5Cfrac{%5Cfrac{%5Coperatorname{arcsin}%5C,%5Cleft(2%5C,x%5Cright)}{2%5Ctimes10^{10}%2Bx^{3}}}{12}+x^{2/3})
-</div>
+$$\operatorname{exp}\\,\left(\sqrt{x}\right)-\frac{\frac{\operatorname{arcsin}\\,\left(2\,x\right)}{2\times10^{10}%2Bx^{3}}}{12}+x^{2/3}$$
 
 Result MathML (can be used with MathJax or other renderers):
 

--- a/kmath-ast/docs/README-TEMPLATE.md
+++ b/kmath-ast/docs/README-TEMPLATE.md
@@ -170,7 +170,7 @@ public fun main() {
 
 Result LaTeX:
 
-$$\operatorname{exp}\\,\left(\sqrt{x}\right)-\frac{\frac{\operatorname{arcsin}\\,\left(2\,x\right)}{2\times10^{10}%2Bx^{3}}}{12}+x^{2/3}$$
+$$\operatorname{exp}\\,\left(\sqrt{x}\right)-\frac{\frac{\operatorname{arcsin}\\,\left(2\\,x\right)}{2\times10^{10}+x^{3}}}{12}+x^{2/3}$$
 
 Result MathML (can be used with MathJax or other renderers):
 


### PR DESCRIPTION
Previous version with a compiled image of the LaTeX formula during page opening has low resolution and looks awful:

![изображение](https://user-images.githubusercontent.com/43728100/173147133-af6a6259-c564-49f5-88ee-da416a93f9ac.png)

[But since not so long ago GitHub added MathJax to Markdown rendering.](https://github.blog/changelog/2022-05-19-render-mathematical-expressions-in-markdown/) And now it looks great:

![изображение](https://user-images.githubusercontent.com/43728100/173151308-4f3c0eba-d2f9-40f6-8dcd-deed2728bb02.png)